### PR TITLE
Add solution

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 5.6
+
+import PackageDescription
+
+let package = Package(
+    name: "Challenge-2",
+    platforms: [.macOS(.v11), .iOS(.v13)],
+    products: [
+        .library(name: "Challenge-2", targets: ["Challenge-2"]),
+    ],
+    targets: [
+        .target(name: "Challenge-2"),
+    ]
+)

--- a/Sources/Challenge-2/AirDropAnimationView.swift
+++ b/Sources/Challenge-2/AirDropAnimationView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+struct AirDropAnimationView: View {
+
+    let recipientName: String
+    @State private var phase: AnimationPhase = .pickRecipient
+
+    @ViewBuilder
+    private var subTitle: some View {
+        switch phase {
+        case .pickRecipient:
+            Text("from Amos")
+                .foregroundColor(Color(red: 222 / 255, green: 222 / 255, blue: 222 / 255))
+        case .waiting:
+            PulsatingText("Waiting...")
+                .foregroundColor(Color(red: 222 / 255, green: 222 / 255, blue: 222 / 255))
+                .opacity(0.7)
+        case .sending:
+            Text("Sending...")
+                .foregroundColor(Color(red: 222 / 255, green: 222 / 255, blue: 222 / 255))
+                .opacity(0.7)
+        case .sent:
+            Text("Sent")
+                .foregroundColor(.blue)
+        }
+    }
+
+    @ViewBuilder
+    private var ringView: some View {
+        let lineWidth: Double = 10
+        switch phase {
+        case .pickRecipient, .waiting:
+            Circle()
+                .stroke(
+                    Color(red: 104 / 255, green: 104 / 255, blue: 106 / 255),
+                    style: .init(lineWidth: lineWidth)
+                )
+                .padding(lineWidth / 2)
+        case .sending:
+            RingProgress(lineWidth: lineWidth)
+        case .sent:
+            Circle()
+                .stroke(
+                    .blue,
+                    style: .init(lineWidth: lineWidth)
+                )
+                .padding(lineWidth / 2)
+        }
+    }
+
+    private func showAnimations() {
+        phase = .pickRecipient
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            phase = .waiting
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
+            phase = .sending
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 6.5) {
+            phase = .sent
+        }
+    }
+
+    var body: some View {
+        VStack {
+            ZStack {
+                Icon()
+                    .padding(14)
+                ringView
+            }
+
+            VStack {
+                Text(recipientName)
+                    .foregroundColor(Color(red: 222 / 255, green: 222 / 255, blue: 222 / 255))
+                subTitle
+            }
+        }
+        .padding()
+        .background(Color(red: 31/255, green: 31/255, blue: 31/255))
+        .onAppear { showAnimations() }
+    }
+}
+
+extension AirDropAnimationView {
+    enum AnimationPhase {
+        case pickRecipient
+        case waiting
+        case sending
+        case sent
+    }
+}
+
+struct AirDropAnimationView_Previews: PreviewProvider {
+    static var previews: some View {
+        AirDropAnimationView(recipientName: "iPhone")
+    }
+}

--- a/Sources/Challenge-2/AirDropAnimationView.swift
+++ b/Sources/Challenge-2/AirDropAnimationView.swift
@@ -93,5 +93,6 @@ extension AirDropAnimationView {
 struct AirDropAnimationView_Previews: PreviewProvider {
     static var previews: some View {
         AirDropAnimationView(recipientName: "iPhone")
+            .previewLayout(.fixed(width: 320, height: 350))
     }
 }

--- a/Sources/Challenge-2/Icon.swift
+++ b/Sources/Challenge-2/Icon.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct Icon: View {
+    var body: some View {
+        GeometryReader { proxy in
+            let strokeWidth = proxy.size.width / 16
+            ZStack {
+                Image(systemName: "person.fill")
+                    .resizable()
+                    .aspectRatio(CGSize(width: 1, height: 1), contentMode: .fit)
+                    .foregroundColor(Color(red: 31/255, green: 31/255, blue: 31/255))
+                    .clipShape(Circle())
+                    .offset(y: 35)
+                    .padding(40)
+                    .background(Color(red: 154/255, green: 154/255, blue: 154/255))
+                Circle()
+                    .stroke(style: .init(lineWidth: strokeWidth))
+                    .foregroundColor(Color(red: 154/255, green: 154/255, blue: 154/255))
+                    .padding(strokeWidth / 2)
+            }
+        }.clipShape(Circle())
+    }
+}
+
+
+struct Icon_Previews: PreviewProvider {
+    static var previews: some View {
+        Icon()
+            .background(Color(red: 31/255, green: 31/255, blue: 31/255))
+    }
+}

--- a/Sources/Challenge-2/PulsatingText.swift
+++ b/Sources/Challenge-2/PulsatingText.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct PulsatingText: View {
+
+    let text: String
+
+    @State private var animationState: Double = 0
+
+    init(_ text: String) {
+        self.text = text
+    }
+
+    private var opacity: Double {
+        1 - animationState
+    }
+
+    var animation: Animation {
+        .default
+        .speed(0.5)
+        .repeatForever()
+    }
+
+    var body: some View {
+        Text(text)
+            .opacity(opacity)
+            .animation(animation, value: animationState)
+            .onAppear { animationState = 1 }
+    }
+}
+
+
+struct PulsatingText_Previews: PreviewProvider {
+    static var previews: some View {
+        PulsatingText("Waiting...")
+    }
+}

--- a/Sources/Challenge-2/RingProgress.swift
+++ b/Sources/Challenge-2/RingProgress.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct RingProgress: View {
+    var trackColor = Color(red: 104 / 255, green: 104 / 255, blue: 106 / 255)
+    var progressColor: Color = .blue
+    var lineWidth: Double = 10
+
+    @State private var progress: Double = 0
+
+    private var animation: Animation {
+        .easeInOut(duration: 2)
+    }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(
+                    trackColor,
+                    style: .init(lineWidth: lineWidth)
+                )
+            Circle()
+                .trim(from: 0, to: progress)
+                .stroke(
+                    progressColor,
+                    style: .init(lineWidth: lineWidth)
+                )
+                .animation(animation, value: progress)
+                .rotationEffect(.degrees(-90))
+        }
+        .padding(lineWidth / 2)
+        .onAppear { progress = 1 }
+    }
+}
+
+
+struct RingProgress_Previews: PreviewProvider {
+    static var previews: some View {
+        RingProgress()
+    }
+}


### PR DESCRIPTION
## My solution

(Best viewed in the `AirDropAnimationView_Previews`)

I've identified four states that the view can be in:
1. "Choose recipient", which shows the subtitle "from Amos" and is otherwise static
2. "Waiting", which shows the subtitle "Waiting..." and pulses indefinitely
3. "Sending", which shows the subtitle "Sending..." and animates the ring progress around the icon
4. "Sent", which shows the subtitle "Sent" and is otherwise static

All in all, there's only two animations:

1. The indefinite pulse in `PulsatingText`
2. The animated ring in `RingProgress`

To show off the animations, I've implemented a function (`showAnimations()`)
that simply iterates through the four phases after some seconds. In a real
implementation, the progress for the "Sending" phase should obviously come from
some network state, but for now it just takes two seconds (hard-coded).

Obviously, this could use a lot more polishing, but I really enjoyed breaking
down the problem into its phases and conquering each individually ✌️


https://user-images.githubusercontent.com/16212751/184546274-c3960358-462c-4555-a6c4-c68e187b8a16.mov


